### PR TITLE
Optimize for a fair comparison

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 # .gitpod.yml  
 tasks:  
-  - name: Setup and Run  
+  - name: Setup and Run Benchmark  
     init: |  
       # Install dependencies  
       go mod tidy  
@@ -12,24 +12,29 @@ tasks:
       # Start MongoDB (single line)  
       docker run --name mongo-json-test -p 27017:27017 -d mongo  
         
-      # Wait for services  
+      # Wait for services to be ready  
       echo "⏳ Waiting for databases to start..."  
-      sleep 15  
+      sleep 20  
         
       # Check if containers are running  
       echo "📋 Container status:"  
       docker ps  
         
       echo ""  
-      echo "✅ Environment ready!"  
+      echo "✅ Databases ready! Starting benchmark..."  
       echo ""  
-      echo "🚀 Quick start commands:"  
-      echo "  go run cmd/main.go           # Run the benchmark"  
-      echo "  docker ps                    # Check running containers"  
+        
+      # Run the benchmark  
+      go run cmd/main.go  
+        
       echo ""  
-      echo "🔍 Database access:"  
-      echo "  docker exec -it pg-json-test psql -U postgres -d testdb"  
-      echo "  docker exec -it mongo-json-test mongosh"  
+      echo "🎉 Benchmark completed!"  
+      echo ""  
+      echo "🔍 For manual database access:"  
+      echo "  PostgreSQL: docker exec -it pg-json-test psql -U postgres -d testdb"  
+      echo "  MongoDB:    docker exec -it mongo-json-test mongosh"  
+      echo ""  
+      echo "🔄 To run benchmark again: go run cmd/main.go"  
   
 ports:  
   - port: 5432  

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-# .gitpod.yml (simplified version)  
+# .gitpod.yml  
 tasks:  
   - name: Setup and Run  
     init: |  
@@ -6,23 +6,21 @@ tasks:
       go mod tidy  
         
     command: |  
-      # Start PostgreSQL  
-      docker run --name pg-json-test \  
-        -e POSTGRES_USER=postgres \  
-        -e POSTGRES_PASSWORD=pass \  
-        -e POSTGRES_DB=testdb \  
-        -p 5432:5432 \  
-        -d postgres  
+      # Start PostgreSQL (single line)  
+      docker run --name pg-json-test -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=pass -e POSTGRES_DB=testdb -p 5432:5432 -d postgres  
         
-      # Start MongoDB  
-      docker run --name mongo-json-test \  
-        -p 27017:27017 \  
-        -d mongo  
+      # Start MongoDB (single line)  
+      docker run --name mongo-json-test -p 27017:27017 -d mongo  
         
       # Wait for services  
       echo "⏳ Waiting for databases to start..."  
       sleep 15  
         
+      # Check if containers are running  
+      echo "📋 Container status:"  
+      docker ps  
+        
+      echo ""  
       echo "✅ Environment ready!"  
       echo ""  
       echo "🚀 Quick start commands:"  

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,44 @@
+# .gitpod.yml (simplified version)  
+tasks:  
+  - name: Setup and Run  
+    init: |  
+      # Install dependencies  
+      go mod tidy  
+        
+    command: |  
+      # Start PostgreSQL  
+      docker run --name pg-json-test \  
+        -e POSTGRES_USER=postgres \  
+        -e POSTGRES_PASSWORD=pass \  
+        -e POSTGRES_DB=testdb \  
+        -p 5432:5432 \  
+        -d postgres  
+        
+      # Start MongoDB  
+      docker run --name mongo-json-test \  
+        -p 27017:27017 \  
+        -d mongo  
+        
+      # Wait for services  
+      echo "⏳ Waiting for databases to start..."  
+      sleep 15  
+        
+      echo "✅ Environment ready!"  
+      echo ""  
+      echo "🚀 Quick start commands:"  
+      echo "  go run cmd/main.go           # Run the benchmark"  
+      echo "  docker ps                    # Check running containers"  
+      echo ""  
+      echo "🔍 Database access:"  
+      echo "  docker exec -it pg-json-test psql -U postgres -d testdb"  
+      echo "  docker exec -it mongo-json-test mongosh"  
+  
+ports:  
+  - port: 5432  
+    onOpen: ignore  
+  - port: 27017  
+    onOpen: ignore  
+  
+vscode:  
+  extensions:  
+    - golang.go  

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,83 +1,93 @@
-package main
-
-import (
-	"Jsonb/benchmark"
-	"Jsonb/internal/db"
-	"fmt"
-	"log"
-	"time"
-
-	"github.com/joho/godotenv"
-)
-
-func init() {
-	start := time.Now()
-
-	if err := godotenv.Load(); err != nil {
-		log.Fatal("❌ Error loading .env file")
-	}
-	fmt.Println("✅ .env loaded")
-
-	pgStart := time.Now()
-	if err := db.ConnectPostgres(); err != nil {
-		log.Fatalf("❌ Postgres connection failed: %v", err)
-	}
-	fmt.Println("✅ Connected to PostgreSQL in", time.Since(pgStart))
-
-	mongoStart := time.Now()
-	if err := db.ConnectMongo(); err != nil {
-		log.Fatalf("❌ MongoDB connection failed: %v", err)
-	}
-	fmt.Println("✅ Connected to MongoDB in", time.Since(mongoStart))
-
-	fmt.Println("🔗 Total DB connection setup time:", time.Since(start))
-}
-
-func main() {
-	// // ✅ 1. CREATE: Insert single record
-	// record := data.DummyData{
-	// 	ID:   999, // Unique JSON ID
-	// 	Name: "CRUD Test User",
-	// 	Age:  42,
-	// 	Address: map[string]string{
-	// 		"city": "TestCity",
-	// 		"zip":  "123456",
-	// 	},
-	// 	Tags: []string{"test", "crud", "jsonb"},
-	// }
-
-	// if err := db.CreatePostgres(record); err != nil {
-	// 	log.Fatal("❌ Failed to create record:", err)
-	// }
-	// fmt.Println("✅ Created single record with data.id = 999")
-
-	// // ✅ 2. READ: Find by JSON field data.id
-	// readRecord, err := db.FindPostgresByID(999)
-	// if err != nil {
-	// 	log.Fatal("❌ Failed to find record by JSON id:", err)
-	// }
-
-	// // Convert datatypes.JSON to map for pretty printing
-	// var jsonMap map[string]interface{}
-	// if err := json.Unmarshal(readRecord.Data, &jsonMap); err != nil {
-	// 	log.Fatal("❌ Failed to unmarshal JSON data:", err)
-	// }
-	// fmt.Printf("🔍 Read record with data.id = 999: %+v\n", jsonMap)
-
-	// // ✅ 3. UPDATE: Change city for records with age >= 40
-	// if err := db.UpdatePostgresCity(40, "UpdatedCity"); err != nil {
-	// 	log.Fatal("❌ Failed to update record(s):", err)
-	// }
-	// fmt.Println("✅ Updated city to 'UpdatedCity' for records where age >= 40")
-
-	// // ✅ 4. DELETE: Delete records where age < 50
-	// if err := db.DeletePostgresByAge(50); err != nil {
-	// 	log.Fatal("❌ Failed to delete record(s):", err)
-	// }
-	// fmt.Println("🗑️ Deleted record(s) where age < 50")
-
-	// fmt.Println("🏁 Full CRUD test completed!")
-	// Run benchmark tests
-	benchmark.RunBenchmark()
-	fmt.Println("🏁 Benchmark tests completed!")
-}
+package main  
+  
+import (  
+	"Jsonb/benchmark"  
+	"Jsonb/internal/db"  
+	"flag"  
+	"fmt"  
+	"log"  
+	"time"  
+  
+	"github.com/joho/godotenv"  
+)  
+  
+func init() {  
+	start := time.Now()  
+  
+	if err := godotenv.Load(); err != nil {  
+		log.Fatal("❌ Error loading .env file")  
+	}  
+	fmt.Println("✅ .env loaded")  
+  
+	pgStart := time.Now()  
+	if err := db.ConnectPostgres(); err != nil {  
+		log.Fatalf("❌ Postgres connection failed: %v", err)  
+	}  
+	fmt.Println("✅ Connected to PostgreSQL in", time.Since(pgStart))  
+  
+	mongoStart := time.Now()  
+	if err := db.ConnectMongo(); err != nil {  
+		log.Fatalf("❌ MongoDB connection failed: %v", err)  
+	}  
+	fmt.Println("✅ Connected to MongoDB in", time.Since(mongoStart))  
+  
+	fmt.Println("🔗 Total DB connection setup time:", time.Since(start))  
+}  
+  
+func main() {  
+	// Parse command line flags  
+	runs := flag.Int("runs", 100, "Number of benchmark runs to execute")  
+	flag.Parse()  
+  
+	// // ✅ 1. CREATE: Insert single record  
+	// record := data.DummyData{  
+	// 	ID:   999, // Unique JSON ID  
+	// 	Name: "CRUD Test User",  
+	// 	Age:  42,  
+	// 	Address: map[string]string{  
+	// 		"city": "TestCity",  
+	// 		"zip":  "123456",  
+	// 	},  
+	// 	Tags: []string{"test", "crud", "jsonb"},  
+	// }  
+  
+	// if err := db.CreatePostgres(record); err != nil {  
+	// 	log.Fatal("❌ Failed to create record:", err)  
+	// }  
+	// fmt.Println("✅ Created single record with data.id = 999")  
+  
+	// // ✅ 2. READ: Find by JSON field data.id  
+	// readRecord, err := db.FindPostgresByID(999)  
+	// if err != nil {  
+	// 	log.Fatal("❌ Failed to find record by JSON id:", err)  
+	// }  
+  
+	// // Convert datatypes.JSON to map for pretty printing  
+	// var jsonMap map[string]interface{}  
+	// if err := json.Unmarshal(readRecord.Data, &jsonMap); err != nil {  
+	// 	log.Fatal("❌ Failed to unmarshal JSON data:", err)  
+	// }  
+	// fmt.Printf("🔍 Read record with data.id = 999: %+v\n", jsonMap)  
+  
+	// // ✅ 3. UPDATE: Change city for records with age >= 40  
+	// if err := db.UpdatePostgresCity(40, "UpdatedCity"); err != nil {  
+	// 	log.Fatal("❌ Failed to update record(s):", err)  
+	// }  
+	// fmt.Println("✅ Updated city to 'UpdatedCity' for records where age >= 40")  
+  
+	// // ✅ 4. DELETE: Delete records where age < 50  
+	// if err := db.DeletePostgresByAge(50); err != nil {  
+	// 	log.Fatal("❌ Failed to delete record(s):", err)  
+	// }  
+	// fmt.Println("🗑️ Deleted record(s) where age < 50")  
+  
+	// fmt.Println("🏁 Full CRUD test completed!")  
+	  
+	// Run benchmark tests  
+	fmt.Printf("🚀 Running benchmark %d time(s)...\n", *runs)  
+	for i := 1; i <= *runs; i++ {  
+		fmt.Printf("📊 Benchmark run %d/%d\n", i, *runs)  
+		benchmark.RunBenchmark()  
+	}  
+	fmt.Printf("🏁 Completed %d benchmark run(s)!\n", *runs)  
+}  

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,93 +1,93 @@
-package main  
-  
-import (  
-	"Jsonb/benchmark"  
-	"Jsonb/internal/db"  
-	"flag"  
-	"fmt"  
-	"log"  
-	"time"  
-  
-	"github.com/joho/godotenv"  
-)  
-  
-func init() {  
-	start := time.Now()  
-  
-	if err := godotenv.Load(); err != nil {  
-		log.Fatal("❌ Error loading .env file")  
-	}  
-	fmt.Println("✅ .env loaded")  
-  
-	pgStart := time.Now()  
-	if err := db.ConnectPostgres(); err != nil {  
-		log.Fatalf("❌ Postgres connection failed: %v", err)  
-	}  
-	fmt.Println("✅ Connected to PostgreSQL in", time.Since(pgStart))  
-  
-	mongoStart := time.Now()  
-	if err := db.ConnectMongo(); err != nil {  
-		log.Fatalf("❌ MongoDB connection failed: %v", err)  
-	}  
-	fmt.Println("✅ Connected to MongoDB in", time.Since(mongoStart))  
-  
-	fmt.Println("🔗 Total DB connection setup time:", time.Since(start))  
-}  
-  
-func main() {  
-	// Parse command line flags  
-	runs := flag.Int("runs", 100, "Number of benchmark runs to execute")  
-	flag.Parse()  
-  
-	// // ✅ 1. CREATE: Insert single record  
-	// record := data.DummyData{  
-	// 	ID:   999, // Unique JSON ID  
-	// 	Name: "CRUD Test User",  
-	// 	Age:  42,  
-	// 	Address: map[string]string{  
-	// 		"city": "TestCity",  
-	// 		"zip":  "123456",  
-	// 	},  
-	// 	Tags: []string{"test", "crud", "jsonb"},  
-	// }  
-  
-	// if err := db.CreatePostgres(record); err != nil {  
-	// 	log.Fatal("❌ Failed to create record:", err)  
-	// }  
-	// fmt.Println("✅ Created single record with data.id = 999")  
-  
-	// // ✅ 2. READ: Find by JSON field data.id  
-	// readRecord, err := db.FindPostgresByID(999)  
-	// if err != nil {  
-	// 	log.Fatal("❌ Failed to find record by JSON id:", err)  
-	// }  
-  
-	// // Convert datatypes.JSON to map for pretty printing  
-	// var jsonMap map[string]interface{}  
-	// if err := json.Unmarshal(readRecord.Data, &jsonMap); err != nil {  
-	// 	log.Fatal("❌ Failed to unmarshal JSON data:", err)  
-	// }  
-	// fmt.Printf("🔍 Read record with data.id = 999: %+v\n", jsonMap)  
-  
-	// // ✅ 3. UPDATE: Change city for records with age >= 40  
-	// if err := db.UpdatePostgresCity(40, "UpdatedCity"); err != nil {  
-	// 	log.Fatal("❌ Failed to update record(s):", err)  
-	// }  
-	// fmt.Println("✅ Updated city to 'UpdatedCity' for records where age >= 40")  
-  
-	// // ✅ 4. DELETE: Delete records where age < 50  
-	// if err := db.DeletePostgresByAge(50); err != nil {  
-	// 	log.Fatal("❌ Failed to delete record(s):", err)  
-	// }  
-	// fmt.Println("🗑️ Deleted record(s) where age < 50")  
-  
-	// fmt.Println("🏁 Full CRUD test completed!")  
-	  
-	// Run benchmark tests  
-	fmt.Printf("🚀 Running benchmark %d time(s)...\n", *runs)  
-	for i := 1; i <= *runs; i++ {  
-		fmt.Printf("📊 Benchmark run %d/%d\n", i, *runs)  
-		benchmark.RunBenchmark()  
-	}  
-	fmt.Printf("🏁 Completed %d benchmark run(s)!\n", *runs)  
-}  
+package main
+
+import (
+	"Jsonb/benchmark"
+	"Jsonb/internal/db"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/joho/godotenv"
+)
+
+func init() {
+	start := time.Now()
+
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("❌ Error loading .env file")
+	}
+	fmt.Println("✅ .env loaded")
+
+	pgStart := time.Now()
+	if err := db.ConnectPostgres(); err != nil {
+		log.Fatalf("❌ Postgres connection failed: %v", err)
+	}
+	fmt.Println("✅ Connected to PostgreSQL in", time.Since(pgStart))
+
+	mongoStart := time.Now()
+	if err := db.ConnectMongo(); err != nil {
+		log.Fatalf("❌ MongoDB connection failed: %v", err)
+	}
+	fmt.Println("✅ Connected to MongoDB in", time.Since(mongoStart))
+
+	fmt.Println("🔗 Total DB connection setup time:", time.Since(start))
+}
+
+func main() {
+	// Parse command line flags
+	runs := flag.Int("runs", 100, "Number of benchmark runs to execute")
+	flag.Parse()
+
+	// // ✅ 1. CREATE: Insert single record
+	// record := data.DummyData{
+	// 	ID:   999, // Unique JSON ID
+	// 	Name: "CRUD Test User",
+	// 	Age:  42,
+	// 	Address: map[string]string{
+	// 		"city": "TestCity",
+	// 		"zip":  "123456",
+	// 	},
+	// 	Tags: []string{"test", "crud", "jsonb"},
+	// }
+
+	// if err := db.CreatePostgres(record); err != nil {
+	// 	log.Fatal("❌ Failed to create record:", err)
+	// }
+	// fmt.Println("✅ Created single record with data.id = 999")
+
+	// // ✅ 2. READ: Find by JSON field data.id
+	// readRecord, err := db.FindPostgresByID(999)
+	// if err != nil {
+	// 	log.Fatal("❌ Failed to find record by JSON id:", err)
+	// }
+
+	// // Convert datatypes.JSON to map for pretty printing
+	// var jsonMap map[string]interface{}
+	// if err := json.Unmarshal(readRecord.Data, &jsonMap); err != nil {
+	// 	log.Fatal("❌ Failed to unmarshal JSON data:", err)
+	// }
+	// fmt.Printf("🔍 Read record with data.id = 999: %+v\n", jsonMap)
+
+	// // ✅ 3. UPDATE: Change city for records with age >= 40
+	// if err := db.UpdatePostgresCity(40, "UpdatedCity"); err != nil {
+	// 	log.Fatal("❌ Failed to update record(s):", err)
+	// }
+	// fmt.Println("✅ Updated city to 'UpdatedCity' for records where age >= 40")
+
+	// // ✅ 4. DELETE: Delete records where age < 50
+	// if err := db.DeletePostgresByAge(50); err != nil {
+	// 	log.Fatal("❌ Failed to delete record(s):", err)
+	// }
+	// fmt.Println("🗑️ Deleted record(s) where age < 50")
+
+	// fmt.Println("🏁 Full CRUD test completed!")
+	
+	// Run benchmark tests
+	fmt.Printf("🚀 Running benchmark %d time(s)...\n", *runs)
+	for i := 1; i <= *runs; i++ {
+		fmt.Printf("📊 Benchmark run %d/%d\n", i, *runs)
+		benchmark.RunBenchmark()
+	}
+	fmt.Printf("🏁 Completed %d benchmark run(s)!\n", *runs)
+}

--- a/internal/db/mongo.go
+++ b/internal/db/mongo.go
@@ -1,100 +1,165 @@
-package db
-
-import (
-	"Jsonb/data"
-	"context"
-	"fmt"
-	"os"
-	"time"
-
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-)
-
-var MongoClient *mongo.Client
-var MongoDB *mongo.Database
-
-// MongoDB connection setup
-func ConnectMongo() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	clientOptions := options.Client().ApplyURI(os.Getenv("MONGO_URI"))
-
-	client, err := mongo.Connect(ctx, clientOptions)
-	if err != nil {
-		return err
-	}
-
-	err = client.Ping(ctx, nil)
-	if err != nil {
-		return err
-	}
-
-	MongoClient = client
-	MongoDB = client.Database(os.Getenv("MONGO_DB"))
-
-	fmt.Println("✅ Connected to MongoDB")
-	return nil
-}
-
-// Create single document
-func CreateMongo(record data.DummyData) error {
-	collection := MongoDB.Collection("json_data")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err := collection.InsertOne(ctx, record)
-	return err
-}
-
-// Insert multiple documents
-func InsertMongo(records []data.DummyData) error {
-	var docs []interface{}
-	for _, record := range records {
-		docs = append(docs, record)
-	}
-	collection := MongoDB.Collection("json_data")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	_, err := collection.InsertMany(ctx, docs)
-	return err
-}
-
-// Find single document by 'id'
-func FindMongoByID(id int) (data.DummyData, error) {
-	collection := MongoDB.Collection("json_data")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	var result data.DummyData
-	err := collection.FindOne(ctx, bson.M{"id": id}).Decode(&result)
-	return result, err
-}
-
-// Update documents where age >= minAge
-func UpdateMongoCity(minAge int, newCity string) error {
-	collection := MongoDB.Collection("json_data")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	filter := bson.M{"age": bson.M{"$gte": minAge}}
-	update := bson.M{"$set": bson.M{"address.city": newCity}}
-
-	_, err := collection.UpdateMany(ctx, filter, update)
-	return err
-}
-
-// Delete documents where age < maxAge
-func DeleteMongoByAge(maxAge int) error {
-	collection := MongoDB.Collection("json_data")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	filter := bson.M{"age": bson.M{"$lt": maxAge}}
-
-	_, err := collection.DeleteMany(ctx, filter)
-	return err
-}
+package db  
+  
+import (  
+	"Jsonb/data"  
+	"context"  
+	"fmt"  
+	"os"  
+	"time"  
+  
+	"go.mongodb.org/mongo-driver/bson"  
+	"go.mongodb.org/mongo-driver/mongo"  
+	"go.mongodb.org/mongo-driver/mongo/options"  
+)  
+  
+var MongoClient *mongo.Client  
+var MongoDB *mongo.Database  
+  
+// MongoDB connection setup  
+func ConnectMongo() error {  
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
+	defer cancel()  
+  
+	clientOptions := options.Client().ApplyURI(os.Getenv("MONGO_URI"))  
+  
+	client, err := mongo.Connect(ctx, clientOptions)  
+	if err != nil {  
+		return err  
+	}  
+  
+	err = client.Ping(ctx, nil)  
+	if err != nil {  
+		return err  
+	}  
+  
+	MongoClient = client  
+	MongoDB = client.Database(os.Getenv("MONGO_DB"))  
+  
+	// Create indexes equivalent to PostgreSQL  
+	collection := MongoDB.Collection("json_data")  
+	  
+	// Index equivalent to PostgreSQL: (data->>'id', id)  
+	// In MongoDB: compound index on (id, _id)  
+	idIndexModel := mongo.IndexModel{  
+		Keys: bson.D{  
+			{Key: "id", Value: 1},  
+			{Key: "_id", Value: 1},  
+		},  
+		Options: options.Index().SetName("idx_id_objectid"),  
+	}  
+  
+	// Index equivalent to PostgreSQL: ((data->>'age')::int)    
+	// In MongoDB: simple index on age field  
+	ageIndexModel := mongo.IndexModel{  
+		Keys: bson.D{  
+			{Key: "age", Value: 1},  
+		},  
+		Options: options.Index().SetName("idx_age"),  
+	}  
+  
+	indexModels := []mongo.IndexModel{idIndexModel, ageIndexModel}  
+	  
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)  
+	defer cancel2()  
+	  
+	_, err = collection.Indexes().CreateMany(ctx2, indexModels)  
+	if err != nil {  
+		return err  
+	}  
+  
+	fmt.Println("✅ Index on (id, _id) created")  
+	fmt.Println("✅ Index on age created")  
+	fmt.Println("✅ Connected to MongoDB")  
+	return nil  
+}  
+  
+// Create single document  
+func CreateMongo(record data.DummyData) error {  
+	collection := MongoDB.Collection("json_data")  
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)  
+	defer cancel()  
+  
+	_, err := collection.InsertOne(ctx, record)  
+	return err  
+}  
+  
+// Bulk insert multiple documents (optimized)  
+func InsertMongoBulk(records []data.DummyData) error {  
+	if len(records) == 0 {  
+		return nil  
+	}  
+  
+	collection := MongoDB.Collection("json_data")  
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)  
+	defer cancel()  
+  
+	// Convert to interface slice  
+	docs := make([]interface{}, len(records))  
+	for i, record := range records {  
+		docs[i] = record  
+	}  
+  
+	// Use ordered=false for better performance  
+	opts := options.InsertMany().SetOrdered(false)  
+	_, err := collection.InsertMany(ctx, docs, opts)  
+	return err  
+}  
+  
+// Insert multiple documents (kept for backward compatibility)  
+func InsertMongo(records []data.DummyData) error {  
+	return InsertMongoBulk(records)  
+}  
+  
+// Find single document by 'id' - uses idx_id_objectid index  
+func FindMongoByID(id int) (data.DummyData, error) {  
+	collection := MongoDB.Collection("json_data")  
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)  
+	defer cancel()  
+  
+	var result data.DummyData  
+	err := collection.FindOne(ctx, bson.M{"id": id}).Decode(&result)  
+	return result, err  
+}  
+  
+// Query by age condition - uses idx_age index  
+func QueryMongo(minAge int) ([]data.DummyData, error) {  
+	collection := MongoDB.Collection("json_data")  
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
+	defer cancel()  
+  
+	filter := bson.M{"age": bson.M{"$gt": minAge}}  
+	cursor, err := collection.Find(ctx, filter)  
+	if err != nil {  
+		return nil, err  
+	}  
+	defer cursor.Close(ctx)  
+  
+	var results []data.DummyData  
+	err = cursor.All(ctx, &results)  
+	return results, err  
+}  
+  
+// Update documents where age > minAge - uses idx_age index  
+func UpdateMongoCity(minAge int, newCity string) error {  
+	collection := MongoDB.Collection("json_data")  
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
+	defer cancel()  
+  
+	filter := bson.M{"age": bson.M{"$gt": minAge}}  
+	update := bson.M{"$set": bson.M{"address.city": newCity}}  
+  
+	_, err := collection.UpdateMany(ctx, filter, update)  
+	return err  
+}  
+  
+// Delete documents where age < maxAge - uses idx_age index  
+func DeleteMongoByAge(maxAge int) error {  
+	collection := MongoDB.Collection("json_data")  
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
+	defer cancel()  
+  
+	filter := bson.M{"age": bson.M{"$lt": maxAge}}  
+  
+	_, err := collection.DeleteMany(ctx, filter)  
+	return err  
+}  

--- a/internal/db/mongo.go
+++ b/internal/db/mongo.go
@@ -1,165 +1,165 @@
-package db  
-  
-import (  
-	"Jsonb/data"  
-	"context"  
-	"fmt"  
-	"os"  
-	"time"  
-  
-	"go.mongodb.org/mongo-driver/bson"  
-	"go.mongodb.org/mongo-driver/mongo"  
-	"go.mongodb.org/mongo-driver/mongo/options"  
-)  
-  
-var MongoClient *mongo.Client  
-var MongoDB *mongo.Database  
-  
-// MongoDB connection setup  
-func ConnectMongo() error {  
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
-	defer cancel()  
-  
-	clientOptions := options.Client().ApplyURI(os.Getenv("MONGO_URI"))  
-  
-	client, err := mongo.Connect(ctx, clientOptions)  
-	if err != nil {  
-		return err  
-	}  
-  
-	err = client.Ping(ctx, nil)  
-	if err != nil {  
-		return err  
-	}  
-  
-	MongoClient = client  
-	MongoDB = client.Database(os.Getenv("MONGO_DB"))  
-  
-	// Create indexes equivalent to PostgreSQL  
-	collection := MongoDB.Collection("json_data")  
-	  
-	// Index equivalent to PostgreSQL: (data->>'id', id)  
-	// In MongoDB: compound index on (id, _id)  
-	idIndexModel := mongo.IndexModel{  
-		Keys: bson.D{  
-			{Key: "id", Value: 1},  
-			{Key: "_id", Value: 1},  
-		},  
-		Options: options.Index().SetName("idx_id_objectid"),  
-	}  
-  
-	// Index equivalent to PostgreSQL: ((data->>'age')::int)    
-	// In MongoDB: simple index on age field  
-	ageIndexModel := mongo.IndexModel{  
-		Keys: bson.D{  
-			{Key: "age", Value: 1},  
-		},  
-		Options: options.Index().SetName("idx_age"),  
-	}  
-  
-	indexModels := []mongo.IndexModel{idIndexModel, ageIndexModel}  
-	  
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)  
-	defer cancel2()  
-	  
-	_, err = collection.Indexes().CreateMany(ctx2, indexModels)  
-	if err != nil {  
-		return err  
-	}  
-  
-	fmt.Println("✅ Index on (id, _id) created")  
-	fmt.Println("✅ Index on age created")  
-	fmt.Println("✅ Connected to MongoDB")  
-	return nil  
-}  
-  
-// Create single document  
-func CreateMongo(record data.DummyData) error {  
-	collection := MongoDB.Collection("json_data")  
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)  
-	defer cancel()  
-  
-	_, err := collection.InsertOne(ctx, record)  
-	return err  
-}  
-  
-// Bulk insert multiple documents (optimized)  
-func InsertMongoBulk(records []data.DummyData) error {  
-	if len(records) == 0 {  
-		return nil  
-	}  
-  
-	collection := MongoDB.Collection("json_data")  
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)  
-	defer cancel()  
-  
-	// Convert to interface slice  
-	docs := make([]interface{}, len(records))  
-	for i, record := range records {  
-		docs[i] = record  
-	}  
-  
-	// Use ordered=false for better performance  
-	opts := options.InsertMany().SetOrdered(false)  
-	_, err := collection.InsertMany(ctx, docs, opts)  
-	return err  
-}  
-  
-// Insert multiple documents (kept for backward compatibility)  
-func InsertMongo(records []data.DummyData) error {  
-	return InsertMongoBulk(records)  
-}  
-  
-// Find single document by 'id' - uses idx_id_objectid index  
-func FindMongoByID(id int) (data.DummyData, error) {  
-	collection := MongoDB.Collection("json_data")  
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)  
-	defer cancel()  
-  
-	var result data.DummyData  
-	err := collection.FindOne(ctx, bson.M{"id": id}).Decode(&result)  
-	return result, err  
-}  
-  
-// Query by age condition - uses idx_age index  
-func QueryMongo(minAge int) ([]data.DummyData, error) {  
-	collection := MongoDB.Collection("json_data")  
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
-	defer cancel()  
-  
-	filter := bson.M{"age": bson.M{"$gt": minAge}}  
-	cursor, err := collection.Find(ctx, filter)  
-	if err != nil {  
-		return nil, err  
-	}  
-	defer cursor.Close(ctx)  
-  
-	var results []data.DummyData  
-	err = cursor.All(ctx, &results)  
-	return results, err  
-}  
-  
-// Update documents where age > minAge - uses idx_age index  
-func UpdateMongoCity(minAge int, newCity string) error {  
-	collection := MongoDB.Collection("json_data")  
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
-	defer cancel()  
-  
-	filter := bson.M{"age": bson.M{"$gt": minAge}}  
-	update := bson.M{"$set": bson.M{"address.city": newCity}}  
-  
-	_, err := collection.UpdateMany(ctx, filter, update)  
-	return err  
-}  
-  
-// Delete documents where age < maxAge - uses idx_age index  
-func DeleteMongoByAge(maxAge int) error {  
-	collection := MongoDB.Collection("json_data")  
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)  
-	defer cancel()  
-  
-	filter := bson.M{"age": bson.M{"$lt": maxAge}}  
-  
-	_, err := collection.DeleteMany(ctx, filter)  
-	return err  
-}  
+package db
+
+import (
+	"Jsonb/data"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var MongoClient *mongo.Client
+var MongoDB *mongo.Database
+
+// MongoDB connection setup
+func ConnectMongo() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientOptions := options.Client().ApplyURI(os.Getenv("MONGO_URI"))
+
+	client, err := mongo.Connect(ctx, clientOptions)
+	if err != nil {
+		return err
+	}
+
+	err = client.Ping(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	MongoClient = client
+	MongoDB = client.Database(os.Getenv("MONGO_DB"))
+
+	// Create indexes equivalent to PostgreSQL
+	collection := MongoDB.Collection("json_data")
+	
+	// Index equivalent to PostgreSQL: (data->>'id', id)
+	// In MongoDB: compound index on (id, _id)
+	idIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "id", Value: 1},
+			{Key: "_id", Value: 1},
+		},
+		Options: options.Index().SetName("idx_id_objectid"),
+	}
+
+	// Index equivalent to PostgreSQL: ((data->>'age')::int)  
+	// In MongoDB: simple index on age field
+	ageIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "age", Value: 1},
+		},
+		Options: options.Index().SetName("idx_age"),
+	}
+
+	indexModels := []mongo.IndexModel{idIndexModel, ageIndexModel}
+	
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel2()
+	
+	_, err = collection.Indexes().CreateMany(ctx2, indexModels)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("✅ Index on (id, _id) created")
+	fmt.Println("✅ Index on age created")
+	fmt.Println("✅ Connected to MongoDB")
+	return nil
+}
+
+// Create single document
+func CreateMongo(record data.DummyData) error {
+	collection := MongoDB.Collection("json_data")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := collection.InsertOne(ctx, record)
+	return err
+}
+
+// Bulk insert multiple documents (optimized)
+func InsertMongoBulk(records []data.DummyData) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	collection := MongoDB.Collection("json_data")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Convert to interface slice
+	docs := make([]interface{}, len(records))
+	for i, record := range records {
+		docs[i] = record
+	}
+
+	// Use ordered=false for better performance
+	opts := options.InsertMany().SetOrdered(false)
+	_, err := collection.InsertMany(ctx, docs, opts)
+	return err
+}
+
+// Insert multiple documents (kept for backward compatibility)
+func InsertMongo(records []data.DummyData) error {
+	return InsertMongoBulk(records)
+}
+
+// Find single document by 'id' - uses idx_id_objectid index
+func FindMongoByID(id int) (data.DummyData, error) {
+	collection := MongoDB.Collection("json_data")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var result data.DummyData
+	err := collection.FindOne(ctx, bson.M{"id": id}).Decode(&result)
+	return result, err
+}
+
+// Query by age condition - uses idx_age index
+func QueryMongo(minAge int) ([]data.DummyData, error) {
+	collection := MongoDB.Collection("json_data")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{"age": bson.M{"$gt": minAge}}
+	cursor, err := collection.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []data.DummyData
+	err = cursor.All(ctx, &results)
+	return results, err
+}
+
+// Update documents where age > minAge - uses idx_age index
+func UpdateMongoCity(minAge int, newCity string) error {
+	collection := MongoDB.Collection("json_data")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{"age": bson.M{"$gt": minAge}}
+	update := bson.M{"$set": bson.M{"address.city": newCity}}
+
+	_, err := collection.UpdateMany(ctx, filter, update)
+	return err
+}
+
+// Delete documents where age < maxAge - uses idx_age index
+func DeleteMongoByAge(maxAge int) error {
+	collection := MongoDB.Collection("json_data")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{"age": bson.M{"$lt": maxAge}}
+
+	_, err := collection.DeleteMany(ctx, filter)
+	return err
+}

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1,132 +1,132 @@
-package db  
-  
-import (  
-	"Jsonb/data"  
-	"encoding/json"  
-	"fmt"  
-	"os"  
-  
-	"gorm.io/datatypes"  
-	"gorm.io/driver/postgres"  
-	"gorm.io/gorm"  
-)  
-  
-var PostgresDB *gorm.DB  
-  
-// Model  
-type JSONData struct {  
-	ID   uint           `gorm:"primaryKey"`  
-	Data datatypes.JSON `gorm:"type:jsonb"`  
-}  
-  
-func ConnectPostgres() error {  
-	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",  
-		os.Getenv("POSTGRES_HOST"),  
-		os.Getenv("POSTGRES_USER"),  
-		os.Getenv("POSTGRES_PASSWORD"),  
-		os.Getenv("POSTGRES_DB"),  
-		os.Getenv("POSTGRES_PORT"),  
-	)  
-  
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})  
-	if err != nil {  
-		return err  
-	}  
-  
-	if err := db.AutoMigrate(&JSONData{}); err != nil {  
-		return err  
-	}  
-  
-	// Create optimized indexes  
-	sql1 := `CREATE INDEX IF NOT EXISTS idx_json_data_id ON json_data ((data->>'id'), id);`  
-	if err := db.Exec(sql1).Error; err != nil {  
-		return err  
-	}  
-	fmt.Println("✅ Index on (data->>'id', id) created (or already exists)")  
-  
-	sql2 := `CREATE INDEX IF NOT EXISTS idx_json_data_age ON json_data (((data->>'age')::int));`  
-	if err := db.Exec(sql2).Error; err != nil {  
-		return err  
-	}  
-	fmt.Println("✅ Index on (data->>'age')::int created (or already exists)")  
-  
-	PostgresDB = db  
-	fmt.Println("✅ Connected and AutoMigrated PostgreSQL")  
-	return nil  
-}  
-  
-// Create Single Record  
-func CreatePostgres(record data.DummyData) error {  
-	jsonBytes, err := json.Marshal(record)  
-	if err != nil {  
-		return err  
-	}  
-  
-	item := JSONData{  
-		Data: datatypes.JSON(jsonBytes),  
-	}  
-  
-	return PostgresDB.Create(&item).Error  
-}  
-  
-// Bulk Insert Multiple Records (Optimized)  
-func InsertPostgresBulk(records []data.DummyData) error {  
-	if len(records) == 0 {  
-		return nil  
-	}  
-  
-	// Convert records to JSONData slice  
-	jsonDataSlice := make([]JSONData, len(records))  
-	for i, record := range records {  
-		jsonBytes, err := json.Marshal(record)  
-		if err != nil {  
-			return fmt.Errorf("failed to marshal record at index %d: %v", i, err)  
-		}  
-		jsonDataSlice[i] = JSONData{  
-			Data: datatypes.JSON(jsonBytes),  
-		}  
-	}  
-  
-	// Bulk insert with batch size for better performance  
-	batchSize := 1000  
-	return PostgresDB.CreateInBatches(jsonDataSlice, batchSize).Error  
-}  
-  
-// Insert Multiple Records (kept for backward compatibility, but now uses bulk insert)  
-func InsertPostgres(records []data.DummyData) error {  
-	return InsertPostgresBulk(records)  
-}  
-  
-// Find by JSON field (data.id)  
-func FindPostgresByID(jsonID int) (JSONData, error) {  
-	var result JSONData  
-	idStr := fmt.Sprintf("%d", jsonID) // Convert int to string because data->>'id' is text  
-	err := PostgresDB.  
-		Where("data->>'id' = ?", idStr). // Uses idx_json_data_id index  
-		First(&result).Error  
-	return result, err  
-}  
-  
-// Query by condition (e.g. age > 30)  
-func QueryPostgres(minAge int) ([]JSONData, error) {  
-	var results []JSONData  
-	err := PostgresDB.  
-		Where("(data->>'age')::int > ?", minAge). // Uses idx_json_data_age index  
-		Find(&results).Error  
-	return results, err  
-}  
-  
-// Update JSON field (change city where age > 40)  
-func UpdatePostgresCity(minAge int, newCity string) error {  
-	return PostgresDB.Exec(`  
-		UPDATE json_data  
-		SET data = jsonb_set(data, '{address,city}', to_jsonb(?::text), false)  
-		WHERE (data->>'age')::int > ?`, newCity, minAge).Error  
-}  
-  
-// Delete by condition (e.g. age < 25)  
-func DeletePostgresByAge(maxAge int) error {  
-	return PostgresDB.Exec(`  
-		DELETE FROM json_data  
-		WHERE (data->>'age')::int < ?`, maxAge).Error  
-}  
+package db
+
+import (
+	"Jsonb/data"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"gorm.io/datatypes"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+var PostgresDB *gorm.DB
+
+// Model
+type JSONData struct {
+	ID   uint           `gorm:"primaryKey"`
+	Data datatypes.JSON `gorm:"type:jsonb"`
+}
+
+func ConnectPostgres() error {
+	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",
+		os.Getenv("POSTGRES_HOST"),
+		os.Getenv("POSTGRES_USER"),
+		os.Getenv("POSTGRES_PASSWORD"),
+		os.Getenv("POSTGRES_DB"),
+		os.Getenv("POSTGRES_PORT"),
+	)
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		return err
+	}
+
+	if err := db.AutoMigrate(&JSONData{}); err != nil {
+		return err
+	}
+
+	// Create optimized indexes
+	sql1 := `CREATE INDEX IF NOT EXISTS idx_json_data_id ON json_data ((data->>'id'), id);`
+	if err := db.Exec(sql1).Error; err != nil {
+		return err
+	}
+	fmt.Println("✅ Index on (data->>'id', id) created (or already exists)")
+
+	sql2 := `CREATE INDEX IF NOT EXISTS idx_json_data_age ON json_data (((data->>'age')::int));`
+	if err := db.Exec(sql2).Error; err != nil {
+		return err
+	}
+	fmt.Println("✅ Index on (data->>'age')::int created (or already exists)")
+
+	PostgresDB = db
+	fmt.Println("✅ Connected and AutoMigrated PostgreSQL")
+	return nil
+}
+
+// Create Single Record
+func CreatePostgres(record data.DummyData) error {
+	jsonBytes, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+
+	item := JSONData{
+		Data: datatypes.JSON(jsonBytes),
+	}
+
+	return PostgresDB.Create(&item).Error
+}
+
+// Bulk Insert Multiple Records (Optimized)
+func InsertPostgresBulk(records []data.DummyData) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	// Convert records to JSONData slice
+	jsonDataSlice := make([]JSONData, len(records))
+	for i, record := range records {
+		jsonBytes, err := json.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("failed to marshal record at index %d: %v", i, err)
+		}
+		jsonDataSlice[i] = JSONData{
+			Data: datatypes.JSON(jsonBytes),
+		}
+	}
+
+	// Bulk insert with batch size for better performance
+	batchSize := 1000
+	return PostgresDB.CreateInBatches(jsonDataSlice, batchSize).Error
+}
+
+// Insert Multiple Records (kept for backward compatibility, but now uses bulk insert)
+func InsertPostgres(records []data.DummyData) error {
+	return InsertPostgresBulk(records)
+}
+
+// Find by JSON field (data.id)
+func FindPostgresByID(jsonID int) (JSONData, error) {
+	var result JSONData
+	idStr := fmt.Sprintf("%d", jsonID) // Convert int to string because data->>'id' is text
+	err := PostgresDB.
+		Where("data->>'id' = ?", idStr). // Uses idx_json_data_id index
+		First(&result).Error
+	return result, err
+}
+
+// Query by condition (e.g. age > 30)
+func QueryPostgres(minAge int) ([]JSONData, error) {
+	var results []JSONData
+	err := PostgresDB.
+		Where("(data->>'age')::int > ?", minAge). // Uses idx_json_data_age index
+		Find(&results).Error
+	return results, err
+}
+
+// Update JSON field (change city where age > 40)
+func UpdatePostgresCity(minAge int, newCity string) error {
+	return PostgresDB.Exec(`
+		UPDATE json_data
+		SET data = jsonb_set(data, '{address,city}', to_jsonb(?::text), false)
+		WHERE (data->>'age')::int > ?`, newCity, minAge).Error
+}
+
+// Delete by condition (e.g. age < 25)
+func DeletePostgresByAge(maxAge int) error {
+	return PostgresDB.Exec(`
+		DELETE FROM json_data
+		WHERE (data->>'age')::int < ?`, maxAge).Error
+}

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1,108 +1,126 @@
-package db
-
-import (
-	"Jsonb/data"
-	"encoding/json"
-	"fmt"
-	"os"
-
-	"gorm.io/datatypes"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
-)
-
-var PostgresDB *gorm.DB
-
-// Model
-type JSONData struct {
-	ID   uint           `gorm:"primaryKey"`
-	Data datatypes.JSON `gorm:"type:jsonb"`
-}
-
-func ConnectPostgres() error {
-	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",
-		os.Getenv("POSTGRES_HOST"),
-		os.Getenv("POSTGRES_USER"),
-		os.Getenv("POSTGRES_PASSWORD"),
-		os.Getenv("POSTGRES_DB"),
-		os.Getenv("POSTGRES_PORT"),
-	)
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		return err
-	}
-
-	if err := db.AutoMigrate(&JSONData{}); err != nil {
-		return err
-	}
-
-	sql := `CREATE INDEX IF NOT EXISTS idx_json_data_gin ON json_data USING GIN (data);`
-	if err := db.Exec(sql).Error; err != nil {
-		return err
-	}
-
-	fmt.Println("✅ GIN index on JSONB 'data' created (or already exists)")
-
-	PostgresDB = db
-	fmt.Println("✅ Connected and AutoMigrated PostgreSQL")
-	return nil
-}
-
-// Create Single Record
-func CreatePostgres(record data.DummyData) error {
-	jsonBytes, err := json.Marshal(record)
-	if err != nil {
-		return err
-	}
-
-	item := JSONData{
-		Data: datatypes.JSON(jsonBytes),
-	}
-
-	return PostgresDB.Create(&item).Error
-}
-
-// Insert Multiple Records
-func InsertPostgres(records []data.DummyData) error {
-	for _, record := range records {
-		if err := CreatePostgres(record); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Find by JSON field (data.id)
-func FindPostgresByID(jsonID int) (JSONData, error) {
-	var result JSONData
-	idStr := fmt.Sprintf("%d", jsonID) // Convert int to string because data->>'id' is text
-	err := PostgresDB.
-		Where("data->>'id' = ?", idStr). // No CAST — use string directly for index scan
-		First(&result).Error
-	return result, err
-}
-
-// Query by condition (e.g. age > 30)
-func QueryPostgres(minAge int) ([]JSONData, error) {
-	var results []JSONData
-	err := PostgresDB.
-		Where("CAST(data->>'age' AS INTEGER) > ?", minAge).
-		Find(&results).Error
-	return results, err
-}
-
-// Update JSON field (change city where age > 40)
-func UpdatePostgresCity(minAge int, newCity string) error {
-	return PostgresDB.Exec(`
-		UPDATE json_data
-		SET data = jsonb_set(data, '{address,city}', to_jsonb(?::text), false)
-		WHERE (data->>'age')::int > ?`, newCity, minAge).Error
-}
-
-// Delete by condition (e.g. age < 25)
-func DeletePostgresByAge(maxAge int) error {
-	return PostgresDB.Exec(`
-		DELETE FROM json_data
-		WHERE (data->>'age')::int < ?`, maxAge).Error
-}
+package db  
+  
+import (  
+	"Jsonb/data"  
+	"encoding/json"  
+	"fmt"  
+	"os"  
+  
+	"gorm.io/datatypes"  
+	"gorm.io/driver/postgres"  
+	"gorm.io/gorm"  
+)  
+  
+var PostgresDB *gorm.DB  
+  
+// Model  
+type JSONData struct {  
+	ID   uint           `gorm:"primaryKey"`  
+	Data datatypes.JSON `gorm:"type:jsonb"`  
+}  
+  
+func ConnectPostgres() error {  
+	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",  
+		os.Getenv("POSTGRES_HOST"),  
+		os.Getenv("POSTGRES_USER"),  
+		os.Getenv("POSTGRES_PASSWORD"),  
+		os.Getenv("POSTGRES_DB"),  
+		os.Getenv("POSTGRES_PORT"),  
+	)  
+  
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})  
+	if err != nil {  
+		return err  
+	}  
+  
+	if err := db.AutoMigrate(&JSONData{}); err != nil {  
+		return err  
+	}  
+  
+	sql := `CREATE INDEX IF NOT EXISTS idx_json_data_gin ON json_data USING GIN (data);`  
+	if err := db.Exec(sql).Error; err != nil {  
+		return err  
+	}  
+  
+	fmt.Println("✅ GIN index on JSONB 'data' created (or already exists)")  
+  
+	PostgresDB = db  
+	fmt.Println("✅ Connected and AutoMigrated PostgreSQL")  
+	return nil  
+}  
+  
+// Create Single Record  
+func CreatePostgres(record data.DummyData) error {  
+	jsonBytes, err := json.Marshal(record)  
+	if err != nil {  
+		return err  
+	}  
+  
+	item := JSONData{  
+		Data: datatypes.JSON(jsonBytes),  
+	}  
+  
+	return PostgresDB.Create(&item).Error  
+}  
+  
+// Bulk Insert Multiple Records (Optimized)  
+func InsertPostgresBulk(records []data.DummyData) error {  
+	if len(records) == 0 {  
+		return nil  
+	}  
+  
+	// Convert records to JSONData slice  
+	jsonDataSlice := make([]JSONData, len(records))  
+	for i, record := range records {  
+		jsonBytes, err := json.Marshal(record)  
+		if err != nil {  
+			return fmt.Errorf("failed to marshal record at index %d: %v", i, err)  
+		}  
+		jsonDataSlice[i] = JSONData{  
+			Data: datatypes.JSON(jsonBytes),  
+		}  
+	}  
+  
+	// Bulk insert with batch size for better performance  
+	batchSize := 1000   
+	return PostgresDB.CreateInBatches(jsonDataSlice, batchSize).Error  
+}  
+  
+// Insert Multiple Records (kept for backward compatibility, but now uses bulk insert)  
+func InsertPostgres(records []data.DummyData) error {  
+	return InsertPostgresBulk(records)  
+}  
+  
+// Find by JSON field (data.id)  
+func FindPostgresByID(jsonID int) (JSONData, error) {  
+	var result JSONData  
+	idStr := fmt.Sprintf("%d", jsonID) // Convert int to string because data->>'id' is text  
+	err := PostgresDB.  
+		Where("data->>'id' = ?", idStr). // No CAST — use string directly for index scan  
+		First(&result).Error  
+	return result, err  
+}  
+  
+// Query by condition (e.g. age > 30)  
+func QueryPostgres(minAge int) ([]JSONData, error) {  
+	var results []JSONData  
+	err := PostgresDB.  
+		Where("CAST(data->>'age' AS INTEGER) > ?", minAge).  
+		Find(&results).Error  
+	return results, err  
+}  
+  
+// Update JSON field (change city where age > 40)  
+func UpdatePostgresCity(minAge int, newCity string) error {  
+	return PostgresDB.Exec(`  
+		UPDATE json_data  
+		SET data = jsonb_set(data, '{address,city}', to_jsonb(?::text), false)  
+		WHERE (data->>'age')::int > ?`, newCity, minAge).Error  
+}  
+  
+// Delete by condition (e.g. age < 25)  
+func DeletePostgresByAge(maxAge int) error {  
+	return PostgresDB.Exec(`  
+		DELETE FROM json_data  
+		WHERE (data->>'age')::int < ?`, maxAge).Error  
+}  


### PR DESCRIPTION
The comparison was not fair, so I optimized the workload so that PostgreSQL and MongoDB are comparable:
- MongoDB does a batch insert, so I changed the row-by-row in PostgreSQL to insert by batch of 1000
- No indexes are created on MongoDB, but an expensive GIN index was created on PostgreSQL, not useful for those queries. I've set the same indexes that can serve the queries. On scalar values, expression index on a JSON path is better and covers range queries (GIN doesn't)
- PostgreSQL is lazy and delays some cleanup to later (vacuum) so it's not fair to compare on a very short run. I changed to run 100 times.

Here are some numbers run on Gitpod:
```
📊 Benchmark run 50/100
✅ Generated 10000 dummy records for benchmarking
📝 PostgreSQL Insert Time: 162.071234ms
📝 MongoDB Insert Time: 152.706244ms
🔍 PostgreSQL Read Time: 753.57µs
🔍 MongoDB Read Time: 653.18µs

2025/06/25 15:40:34 /workspace/Jsonb-Postgresql/internal/db/postgresql.go:121 SLOW SQL >= 200ms
[13584.321ms] [rows:732708]   
                UPDATE json_data  
                SET data = jsonb_set(data, '{address,city}', to_jsonb('BenchCity'::text), false)  
                WHERE (data->>'age')::int > 30
✏️ PostgreSQL Update Time: 13.584429055s
✏️ MongoDB Update Time: 4.375644751s
🗑️ PostgreSQL Delete Time: 1.26462ms
🗑️ MongoDB Delete Time: 621.82µs
```
MongoDB performs faster on insert, read, and delete operations, with a significant advantage in update tasks. 